### PR TITLE
Complete 3 out of 4 TODOs in code

### DIFF
--- a/xplane_apt_convert/base.py
+++ b/xplane_apt_convert/base.py
@@ -195,7 +195,15 @@ class ParsedAirport:
                 if startup_location is not None:
                     self.startup_locations.append(startup_location)
 
-                # TODO: process RowCode.START_LOCATION_EXT (startup location metadata)
+            elif row_code == AptDat.RowCode.START_LOCATION_EXT:
+                logger.debug("Parsing startup location metadata row.")
+
+                if self.startup_locations:
+                    tokens = row.tokens
+                    last = self.startup_locations[-1]
+                    last.width_code = tokens[1] if len(tokens) > 1 else None
+                    last.operation_type = tokens[2] if len(tokens) > 2 else None
+                    last.airline_codes = " ".join(tokens[3:]) if len(tokens) > 3 else None
 
             elif row_code == AptDat.RowCode.WINDSOCK:
                 logger.debug("Parsing sign row.")

--- a/xplane_apt_convert/base.py
+++ b/xplane_apt_convert/base.py
@@ -18,6 +18,7 @@ from .classes import (
     Sign,
     StartupLocation,
     Windsock,
+    logged_unknowns,
 )
 from .geometry import _DEFAULT_BEZIER_RESOLUTION
 from .iterators import BIterator
@@ -141,6 +142,7 @@ class ParsedAirport:
                 A higher number means more resolution but also larger file sizes on export.
                 Default 16.
         """
+        logged_unknowns.clear()
         self._airport = airport
         self.id = None
         self.metadata = AptMetadata()

--- a/xplane_apt_convert/base.py
+++ b/xplane_apt_convert/base.py
@@ -199,11 +199,7 @@ class ParsedAirport:
                 logger.debug("Parsing startup location metadata row.")
 
                 if self.startup_locations:
-                    tokens = row.tokens
-                    last = self.startup_locations[-1]
-                    last.width_code = tokens[1] if len(tokens) > 1 else None
-                    last.operation_type = tokens[2] if len(tokens) > 2 else None
-                    last.airline_codes = " ".join(tokens[3:]) if len(tokens) > 3 else None
+                    self.startup_locations[-1].enrich_from_metadata_line(row)
 
             elif row_code == AptDat.RowCode.WINDSOCK:
                 logger.debug("Parsing sign row.")

--- a/xplane_apt_convert/classes.py
+++ b/xplane_apt_convert/classes.py
@@ -18,7 +18,6 @@ except ImportError as e:
 
 logger = logging.getLogger("xplane_apt_convert")
 
-# TODO: this should be reset with each different airport parsing
 logged_unknowns = set()
 
 

--- a/xplane_apt_convert/classes.py
+++ b/xplane_apt_convert/classes.py
@@ -521,6 +521,12 @@ class StartupLocation(AptFeature):
             name=" ".join(tokens[6:]),
         )
 
+    def enrich_from_metadata_line(self, line: AptDat.AptDatLine) -> None:
+        tokens = line.tokens
+        self.width_code = tokens[1] if len(tokens) > 1 else None
+        self.operation_type = tokens[2] if len(tokens) > 2 else None
+        self.airline_codes = " ".join(tokens[3:]) if len(tokens) > 3 else None
+
     @staticmethod
     def _schema():
         return {

--- a/xplane_apt_convert/classes.py
+++ b/xplane_apt_convert/classes.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 import logging
+from typing import Optional
 
 from .geometry import get_paths
 from .iterators import BIterator
@@ -504,6 +505,9 @@ class StartupLocation(AptFeature):
     location_type: str
     airplane_types: str
     name: str
+    width_code: Optional[str] = None
+    operation_type: Optional[str] = None
+    airline_codes: Optional[str] = None
 
     @staticmethod
     def from_line(line: AptDat.AptDatLine) -> "StartupLocation":
@@ -527,6 +531,9 @@ class StartupLocation(AptFeature):
                     ("location_type", "str"),
                     ("airplane_types", "str"),
                     ("name", "str"),
+                    ("width_code", "str"),
+                    ("operation_type", "str"),
+                    ("airline_codes", "str"),
                 ]
             ),
         }
@@ -542,6 +549,9 @@ class StartupLocation(AptFeature):
                 "location_type": self.location_type,
                 "airplane_types": self.airplane_types,
                 "name": self.name,
+                "width_code": self.width_code,
+                "operation_type": self.operation_type,
+                "airline_codes": self.airline_codes,
             },
         }
 

--- a/xplane_apt_convert/geometry.py
+++ b/xplane_apt_convert/geometry.py
@@ -70,8 +70,8 @@ def get_paths(row_iterator, bezier_resolution, mode="line"):
             if in_bezier:
                 temp_bezier_nodes.append((lon, lat))
                 coordinates.extend(
-                    _calculate_bezier(*temp_bezier_nodes)
-                )  # TODO: pass resolution argument
+                    _calculate_bezier(*temp_bezier_nodes, resolution=bezier_resolution)
+                )
                 temp_bezier_nodes = []
             else:
                 coordinates.append((lon, lat))


### PR DESCRIPTION
**1. Parse StartupLocation metadata (row 1301)**
The apt.dat format has an optional line after each startup location (row 1301)
that carries extra info: the width code, operation type, and airline codes.
Until now the parser was just throwing that data away. These fields are now
parsed and available as optional attributes on `StartupLocation`.

**2. Fix bezier resolution not being forwarded in get_paths** 
The bezier_resolution argument is now passed as a parameter of `_calculate_bezier`.

**3. Clear logged unknowns between airport parses**
When parsing multiple airports in one session, unknown row codes seen in
the first airport kept showing up as warnings for every subsequent one.
The set of logged unknowns is now cleared between airports.